### PR TITLE
Refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>fr.etrenak</groupId>
+    <groupId>fr.devsylone</groupId>
     <artifactId>fkupdater</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <properties>
         <java.version>1.8</java.version>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -17,6 +19,15 @@
             <url>https://creativecommons.org/licenses/by-nc-nd/4.0/</url>
         </license>
     </licenses>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
 
     <repositories>
         <repository>

--- a/src/main/java/fr/devsylone/fkupdater/FkUpdater.java
+++ b/src/main/java/fr/devsylone/fkupdater/FkUpdater.java
@@ -2,18 +2,16 @@ package fr.devsylone.fkupdater;
 
 import java.io.File;
 
-import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.plugin.InvalidDescriptionException;
 import org.bukkit.plugin.InvalidPluginException;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.UnknownDependencyException;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
-public class FkUpdater extends JavaPlugin implements CommandExecutor
+public class FkUpdater extends JavaPlugin
 {
 	@Override
 	public void onEnable()
@@ -24,41 +22,32 @@ public class FkUpdater extends JavaPlugin implements CommandExecutor
 	@Override
 	public boolean onCommand(CommandSender sender, Command command, String label, String[] args)
 	{
-		if(sender instanceof ConsoleCommandSender)
-		{
-			if(command.getName().equals("fkupdate"))
-			{
-				if(args.length > 1)
-				{
-					for(Plugin p : Bukkit.getPluginManager().getPlugins())
-					{
-						if(p.getName().equalsIgnoreCase("FallenKingdom"))
-						{
-							Bukkit.getPluginManager().disablePlugin(p);
-							break;
-						}
-					}
-					new File(args[0]).delete();
-					
-					try
-					{
-						Plugin p  = Bukkit.getPluginManager().loadPlugin(new File(args[1]));
-						Bukkit.getPluginManager().enablePlugin(p);
-						Bukkit.getScheduler().scheduleSyncDelayedTask(this, new Runnable()
-						{
-							
-							@Override
-							public void run()
-							{
-								Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "fallenkingdom:fk updated " +  FkUpdater.class.getProtectionDomain().getCodeSource().getLocation().getPath());
-							}
-						}, 40l);
-					}catch(UnknownDependencyException | InvalidPluginException | InvalidDescriptionException e)
-					{
-						e.printStackTrace();
-					}
-				}
-			}
+		if(!(sender instanceof ConsoleCommandSender) || args.length < 2)
+			return true;
+
+		PluginManager pluginManager = this.getServer().getPluginManager();
+		Plugin prevPlugin = pluginManager.getPlugin("FallenKingdom");
+		if(prevPlugin != null)
+			pluginManager.disablePlugin(prevPlugin);
+
+		if(!new File(args[0]).delete())
+			this.getLogger().severe("Unable to delete the previous version of the plugin.");
+
+		try {
+			Plugin nextPlugin = pluginManager.loadPlugin(new File(args[1]));
+			if(nextPlugin == null)
+				throw new IllegalArgumentException("Unable to load the next version of the plugin.");
+
+			pluginManager.enablePlugin(nextPlugin);
+
+			this.getServer().dispatchCommand(
+					this.getServer().getConsoleSender(),
+					"fallenkingdom:fk updated " + FkUpdater.class.getProtectionDomain().getCodeSource().getLocation().getPath()
+			);
+
+			pluginManager.disablePlugin(this);
+		} catch (InvalidPluginException | InvalidDescriptionException e) {
+			e.printStackTrace();
 		}
 		return true;
 	}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,10 +1,9 @@
 name: FkUpdater
-version: 1.0.0
+version: ${project.version}
+api-version: 1.13
 author: Devsylone_Team
 authors: [Etrenak, fabulacraft]
 main: fr.devsylone.fkupdater.FkUpdater
-prefix: FKUpdater
-
 
 commands:
  fkupdate:


### PR DESCRIPTION
- Refactoring de la classe principale pour retirer les *if* inutiles
(*JavaPlugin* implémente déjà de *TabExecutor*, et la commande reçue sera toujours `/fkupdater` telle qu'elle est déclarée)
- Changement du *pom.xml* pour pouvoir compiler avec `mvn package`
- Ajout du champ `api-version: 1.13` dans le *plugin.yml*, pour éviter que les serveurs en 1.15 et plus ne chargent les materials legacy inutilement
- Changement du *groupId* pour refléter le package du plugin
- Traitement des fichiers *resources* pour que le champ `version` du *plugin.yml* soit automatiquement complété
- Le délai avant que la commande `updated` soit exécutée a été retiré